### PR TITLE
[PKG-1494] spark-nlp 5.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 0
+  # openjdk=11 isn't available on s390x and ppc64le
+  skip: true  # [linux and (s390x or ppc64le)]
   script:
     - cd python
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
@@ -26,6 +28,9 @@ requirements:
     - python
     - openjdk >=8
     - pyspark >=3.3.1
+    # jupyter metapackage is a recommended dependency. It's not mentioned in setup.py but in README.md,
+    # see https://github.com/JohnSnowLabs/spark-nlp/tree/5.1.2#jupyter-notebook-python
+    - jupyter
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,10 @@ source:
   sha256: 4902148a98e61d49dbce69223eaf65dedcaaad752300d901a847de1173a7dc00
 
 build:
+  number: 0
   script:
     - cd python
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  number: 0
 
 requirements:
   host:


### PR DESCRIPTION
Changelog: https://github.com/JohnSnowLabs/spark-nlp/blob/5.1.2/CHANGELOG
License: https://github.com/JohnSnowLabs/spark-nlp/blob/5.1.2/LICENSE
Requirements:
- https://github.com/JohnSnowLabs/spark-nlp/tree/5.1.2#requirements
- https://github.com/JohnSnowLabs/spark-nlp/tree/5.1.2#quick-start
- https://github.com/JohnSnowLabs/spark-nlp/blob/5.1.2/python/setup.py
- https://github.com/JohnSnowLabs/spark-nlp/tree/5.1.2#jupyter-notebook-python

Actions:
1. Create a new feedstock with the recipe
2. Skip `s390x` and `ppc64le` because of a missing `openjdk`
3. Add `jupyter` metapackage as a recommended dependency. The documentation even says `Of course you will need to have jupyter installed in your system`, see https://sparknlp.org/docs/en/install#quick-install

Notes:
- We want the **python interface** primarily. Apache Spark is still unavailable on defaults